### PR TITLE
Fix missing fragment in dashboard layout

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -465,6 +465,9 @@ export default function Dashboard() {
                       </>
                     )}
                   </div>
+                  </>
+                )}
+                </div>
 
                 {/* Right Column - Analytics */}
                 <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- Close the sidebar fragment and conditional in `pages/index.js`
- Ensure the left column container is properly terminated before rendering analytics

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5afc1517c8333989344b314216d80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted JSX structure in the left column (CSV Upload, Instructions, File List) to properly balance conditional rendering blocks.
  * Ensured the left pane’s rendering scope ends before the Right Column (Analytics) markup.

* **Notes**
  * No changes to analytics content, data flow, or interactions.
  * No updates to public APIs or exports.
  * No user-facing behavioral changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->