### PR TITLE
Handle missing ALLOWED_USERS config

### DIFF
--- a/components/AdminModal.js
+++ b/components/AdminModal.js
@@ -6,6 +6,10 @@ export default function AdminModal({ isOpen, onClose }) {
 
   if (!isOpen || !session?.user?.isAdmin) return null
 
+  const envAdmins = process.env.ALLOWED_USERS
+    ? process.env.ALLOWED_USERS.split(',').map(email => email.trim()).filter(email => email)
+    : []
+
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
       <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
@@ -44,7 +48,7 @@ export default function AdminModal({ isOpen, onClose }) {
                     <span className="text-sm text-gray-800 font-medium">rasmus@wolthers.com</span>
                     <span className="ml-2 text-xs text-gray-600 bg-white px-2 py-1 rounded border">hardcoded admin</span>
                   </div>
-                  {process.env.ALLOWED_USERS?.split(',').map(email => email.trim()).filter(email => email).map(email => (
+                  {envAdmins.map(email => (
                     <div key={email} className="flex items-center">
                       <div className="w-2 h-2 bg-emerald-600 rounded-full mr-3"></div>
                       <span className="text-sm text-gray-800">{email}</span>

--- a/components/AdminPanel.js
+++ b/components/AdminPanel.js
@@ -28,7 +28,9 @@ export default function AdminPanel() {
 
   const getAdminUsers = () => {
     const hardcodedAdmins = ['daniel@wolthers.com']
-    const envAdmins = process.env.ALLOWED_USERS?.split(',').map(email => email.trim().toLowerCase()) || []
+    const envAdmins = process.env.ALLOWED_USERS
+      ? process.env.ALLOWED_USERS.split(',').map(email => email.trim().toLowerCase())
+      : []
     return [...hardcodedAdmins, ...envAdmins]
   }
 
@@ -55,7 +57,10 @@ export default function AdminPanel() {
                 <span className="text-sm text-green-800 font-medium">rasmus@wolthers.com</span>
                 <span className="ml-2 text-xs text-green-600">(hardcoded admin)</span>
               </div>
-              {process.env.ALLOWED_USERS?.split(',').map(email => email.trim()).filter(email => email).map(email => (
+              {(process.env.ALLOWED_USERS
+                ? process.env.ALLOWED_USERS.split(',').map(email => email.trim()).filter(email => email)
+                : []
+              ).map(email => (
                 <div key={email} className="flex items-center">
                   <div className="w-2 h-2 bg-green-400 rounded-full mr-2"></div>
                   <span className="text-sm text-green-800">{email}</span>

--- a/utils/permissions.js
+++ b/utils/permissions.js
@@ -4,7 +4,9 @@ export function canAccessAllData(session) {
 
 export function isAdminUser(email) {
   const hardcodedAdmins = ['daniel@wolthers.com', 'rasmus@wolthers.com'];
-  const envAdmins = process.env.ALLOWED_USERS?.split(',').map(email => email.trim().toLowerCase()) || [];
+  const envAdmins = process.env.ALLOWED_USERS
+    ? process.env.ALLOWED_USERS.split(',').map(email => email.trim().toLowerCase())
+    : [];
   const allAdmins = [...hardcodedAdmins, ...envAdmins];
   return email && allAdmins.includes(email.toLowerCase());
 }


### PR DESCRIPTION
## Summary
- prevent crash when `ALLOWED_USERS` env var is undefined
- safely display environment-sourced admin emails in admin components

## Testing
- `npm run build`
- `npm run lint` *(fails: interactive prompt to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b796af308333955ae6a4fbdab98a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevented runtime errors when the environment-based admin list is not configured.
  - Admin panel now only displays environment-provided admins when available; otherwise, it hides that section.

- Refactor
  - Standardized, safe parsing of environment-provided admin emails (split, trim, lowercase) across the app.
  - Centralized use of the parsed environment admin list for rendering and permission checks.

- Style
  - Minor formatting cleanups with no impact on behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->